### PR TITLE
Add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1753429684,
+        "narHash": "sha256-9h7+4/53cSfQ/uA3pSvCaBepmZaz/dLlLVJnbQ+SJjk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7fd36ee82c0275fb545775cc5e4d30542899511d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1753497720,
+        "narHash": "sha256-yzZkDMVfPpNyTciQOfriWpRXrgGNT/cvrFAEQZ//SZs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c8b8b812010515b7d9bd7e538f06a9f4edb373ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "Lightweight alternative to udiskie";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    rust-overlay,
+  }: let
+    supportedSystems = ["x86_64-linux"];
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    pkgsFor = nixpkgs.legacyPackages;
+
+    udiskr-package = {pkgs ? import <nixpkgs> {}}: let
+      rust-overlay-pkgs = pkgs.extend rust-overlay.overlays.default;
+
+      rustPlatform = pkgs.makeRustPlatform {
+        cargo = rust-overlay-pkgs.rust-bin.nightly.latest.minimal;
+        rustc = rust-overlay-pkgs.rust-bin.nightly.latest.minimal;
+      };
+      manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
+    in
+      rustPlatform.buildRustPackage {
+        pname = manifest.name;
+        version = manifest.version;
+        cargoLock.lockFile = ./Cargo.lock;
+        src = pkgs.lib.cleanSource ./.;
+      };
+  in {
+    packages = forAllSystems (system: {
+      default = pkgsFor.${system}.callPackage udiskr-package {};
+    });
+  };
+}


### PR DESCRIPTION
Added Nix flake for building and using project in Nix based environments.

This allows Nix users to import the project, as it can be seen [here](https://github.com/GaspardCulis/dotfiles/blob/acfa0e0821c94f3064e49f88589a05580aefc8a6/flake.nix#L63) in my system config (using my fork for now), and then use it in their system, like [here](https://github.com/GaspardCulis/dotfiles/blob/acfa0e0821c94f3064e49f88589a05580aefc8a6/modules/home/desktop/misc/udiskr.nix) in my config.